### PR TITLE
add optional iterations param to update

### DIFF
--- a/pyprind/progbar.py
+++ b/pyprind/progbar.py
@@ -60,8 +60,8 @@ class ProgBar(Prog):
                 self._print_eta()
         self.last_progress = progress
 
-    def update(self):
+    def update(self, iterations=1):
         """Updates the progress bar in every iteration of the task."""
-        self.cnt += 1
+        self.cnt += iterations
         self._print_bar()
         self._finish() 

--- a/pyprind/progpercent.py
+++ b/pyprind/progpercent.py
@@ -33,9 +33,9 @@ class ProgPercent(Prog):
                 self._stream_out(' | ETA[sec]: {:.3f} '.format(self._calc_eta()))  
             self._stream_flush()
 
-    def update(self):
+    def update(self, iterations=1):
         """Updates the percentage indicator in every iteration of the task."""
-        self.cnt += 1
+        self.cnt += iterations
         next_perc = self._calc_percent()
         if next_perc > self.perc:
             self.perc = next_perc


### PR DESCRIPTION
Sometimes it's helpful to be able to increment the internal count by more than 1 at once (e.g. i/o operations). This commit adds an optional iterations parameter to the update methods which enables this feature.
