### PR TITLE
psutil: get_cpu_percent and get_memory_percent are deprecated

### DIFF
--- a/pyprind/prog_class.py
+++ b/pyprind/prog_class.py
@@ -139,11 +139,11 @@ class Prog():
                                                                str_end, self.total_time)
         else:
             try:
+                cpu_total = self.process.cpu_percent()
+                mem_total = self.process.memory_percent()
+            except AttributeError: # old version of psutil
                 cpu_total = self.process.get_cpu_percent()
                 mem_total = self.process.get_memory_percent()
-            except AttributeError: # old version of psutil
-                cpu_total = self.process.cpu_percent()
-                mem_total = self.process.memory_percent()    
 
             return 'Title: {}\n'\
                    '  Started: {}\n'\

--- a/pyprind/progbar.py
+++ b/pyprind/progbar.py
@@ -44,11 +44,11 @@ class ProgBar(Prog):
         self._print_progress_bar(0)
         if monitor:
             try:
+                self.process.cpu_percent()
+                self.process.memory_percent()
+            except AttributeError: # old version of psutil
                 self.process.get_cpu_percent()
                 self.process.get_memory_percent()
-            except AttributeError: # old version of psutil
-                cpu_total = self.process.cpu_percent()
-                mem_total = self.process.memory_percent()   
         if self.item_id:
             self._print_item_id()
 

--- a/pyprind/progpercent.py
+++ b/pyprind/progpercent.py
@@ -37,11 +37,11 @@ class ProgPercent(Prog):
         self._print()
         if monitor:
             try:
+                self.process.cpu_percent()
+                self.process.memory_percent()
+            except AttributeError: # old version of psutil
                 self.process.get_cpu_percent()
                 self.process.get_memory_percent()
-            except AttributeError: # old version of psutil
-                cpu_total = self.process.cpu_percent()
-                mem_total = self.process.memory_percent()   
 
 
     def _print(self):


### PR DESCRIPTION
In favor of cpu_percent and memory_percent since 2.0 of psutil (https://github.com/giampaolo/psutil/blob/master/HISTORY.rst#200---2014-03-10)