### PR TITLE
Fix #15: Don't install requirements.txt

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 
 setup(name='PyPrind',
       version='2.9.3',
@@ -10,7 +10,6 @@ setup(name='PyPrind',
       data_files=[('', ['LICENSE.txt']),
                   ('', ['README.html']),
                   ('', ['CHANGELOG.txt']),
-                  ('', ['requirements.txt']),
                   ('examples', ['examples/ex1_percentage_indicator_stderr.py']),
                   ('examples', ['examples/ex1_percentage_indicator_stdout.py']),
                   ('examples', ['examples/ex1_progress_bar_stderr.py']),


### PR DESCRIPTION
No reason to install a requirements.txt file through setup.py – especially if it doesn't exist. Also, setuptools is *so* much better than distutils so use that instead. Fixes #15.