### PR TITLE
Time in day, hour, min and sec

### DIFF
--- a/pyprind/prog_class.py
+++ b/pyprind/prog_class.py
@@ -95,6 +95,25 @@ class Prog():
     def _no_stream(self, text=None):
         """ Called when no valid output stream is available. """
         pass
+    
+    def _get_time(self, time):
+    	ans = ''
+    	days = int(time // 86400)
+    	time -= 86400 * days
+    	hrs = int(time // 3600)
+    	time -= 3600 * hrs 
+    	minutes = int(time // 60)
+    	time -= 60 * minutes
+    	sec = int(round(time))
+    	if (days):
+    		ans += str(days) + ' day '
+    	if (hrs):
+    		ans += str(hrs) + ' hour '
+    	if (minutes):
+    		ans += str(minutes) + ' min '
+    	if (time):
+    		ans += str(sec) + ' sec     '  # To erase the initial sec
+    	return ans;
 
     def _finish(self):
         """ Determines if maximum number of iterations (seed) is reached. """
@@ -104,7 +123,7 @@ class Prog():
             self.last_progress -= 1  # to force a refreshed _print()
             self._print()
             if self.track:
-                self._stream_out('\nTotal time elapsed: {:.3f} sec'.format(self.total_time))
+                self._stream_out('\nTotal time elapsed: ' + self._get_time(self.total_time))
             self._stream_out('\n')
             self.active = False
 
@@ -117,7 +136,7 @@ class Prog():
     def _print_eta(self):
         """ Prints the estimated time left."""
         self._calc_eta()
-        self._stream_out(' | ETA[sec]: {:.3f} '.format(self.eta))
+        self._stream_out(' | ETA: ' + self._get_time(self.eta))
         self._stream_flush()
 
     def _print_item_id(self):
@@ -133,9 +152,9 @@ class Prog():
         time_info = 'Title: {}\n'\
                     '  Started: {}\n'\
                     '  Finished: {}\n'\
-                    '  Total time elapsed: {:.3f} sec'.format(
+                    '  Total time elapsed: '.format(
                             self.title, str_start,
-                            str_end, self.total_time)
+                            str_end) + self._get_time(self.total_time)
         if self.monitor:
             try:
                 cpu_total = self.process.cpu_percent()

--- a/pyprind/prog_class.py
+++ b/pyprind/prog_class.py
@@ -96,24 +96,11 @@ class Prog():
         """ Called when no valid output stream is available. """
         pass
     
-    def _get_time(self, time):
-    	ans = ''
-    	days = int(time // 86400)
-    	time -= 86400 * days
-    	hrs = int(time // 3600)
-    	time -= 3600 * hrs 
-    	minutes = int(time // 60)
-    	time -= 60 * minutes
-    	sec = int(round(time))
-    	if (days):
-    		ans += str(days) + ' day '
-    	if (hrs):
-    		ans += str(hrs) + ' hour '
-    	if (minutes):
-    		ans += str(minutes) + ' min '
-    	if (time):
-    		ans += str(sec) + ' sec     '  # To erase the initial sec
-    	return ans
+    def _get_time(self, _time):
+		if (_time < 86400):
+			return time.strftime("%H:%M:%S", time.gmtime(_time))
+		else:
+			return str(_time//3600) + time.strftime("%H:%M:%S", time.gmtime(_time))[2:]
 
     def _finish(self):
         """ Determines if maximum number of iterations (seed) is reached. """

--- a/pyprind/prog_class.py
+++ b/pyprind/prog_class.py
@@ -100,7 +100,7 @@ class Prog():
 		if (_time < 86400):
 			return time.strftime("%H:%M:%S", time.gmtime(_time))
 		else:
-			return str(_time//3600) + time.strftime("%H:%M:%S", time.gmtime(_time))[2:]
+			return str(_time//3600) + time.strftime("%M:%S", time.gmtime(_time))
 
     def _finish(self):
         """ Determines if maximum number of iterations (seed) is reached. """

--- a/pyprind/prog_class.py
+++ b/pyprind/prog_class.py
@@ -100,7 +100,7 @@ class Prog():
 		if (_time < 86400):
 			return time.strftime("%H:%M:%S", time.gmtime(_time))
 		else:
-			return str(_time//3600) + time.strftime("%M:%S", time.gmtime(_time))
+			return str(int(_time//3600)) + ':' + time.strftime("%M:%S", time.gmtime(_time))
 
     def _finish(self):
         """ Determines if maximum number of iterations (seed) is reached. """

--- a/pyprind/prog_class.py
+++ b/pyprind/prog_class.py
@@ -113,7 +113,7 @@ class Prog():
     		ans += str(minutes) + ' min '
     	if (time):
     		ans += str(sec) + ' sec     '  # To erase the initial sec
-    	return ans;
+    	return ans
 
     def _finish(self):
         """ Determines if maximum number of iterations (seed) is reached. """

--- a/pyprind/progpercent.py
+++ b/pyprind/progpercent.py
@@ -51,8 +51,7 @@ class ProgPercent(Prog):
             self.last_progress = next_perc
             self._stream_out('\r[%3d %%]' % (self.last_progress))
             if self.track:
-                self._stream_out(' elapsed[sec]: {:.3f}'.format(
-                                                            self._elapsed()))
+                self._stream_out(' elapsed: ' + self._get_time(self._elapsed()))
                 self._print_eta()
             if self.item_id:
                 self._print_item_id()

--- a/pyprind/progpercent.py
+++ b/pyprind/progpercent.py
@@ -51,7 +51,7 @@ class ProgPercent(Prog):
             self.last_progress = next_perc
             self._stream_out('\r[%3d %%]' % (self.last_progress))
             if self.track:
-                self._stream_out(' elapsed: ' + self._get_time(self._elapsed()))
+                self._stream_out(' Time elapsed: ' + self._get_time(self._elapsed()))
                 self._print_eta()
             if self.item_id:
                 self._print_item_id()

--- a/test/percentage_indicator.py
+++ b/test/percentage_indicator.py
@@ -1,57 +1,49 @@
-# Sebastian Raschka 2014
-#
-# Progress Percentage class to instantiate a percentage indicator object
-# that is printed to the standard output screen to visualize the
-# progress in a iterative Python procedure
+import sys
+import pyprind
 
-from pyprind.prog_class import Prog
+print('\n%s' % (80 * '='))
+print('%s\n' % (80 * '='))
+print('Testing Basic Percentage Indicator\n')
+
+n = 100000
+perc = pyprind.ProgPercent(n)
+for i in range(n):
+    perc.update()
+
+print('\n%s' % (80 * '='))
+print('%s\n' % (80 * '='))
+print('Testing stdout Stream\n')
+
+perc = pyprind.ProgPercent(n, stream=sys.stdout)
+for i in range(n):
+    perc.update()
 
 
-class ProgPercent(Prog):
-    """
-    Initializes a progress bar object that allows visuzalization
-    of an iterational computation in the standard output screen.
+print('\n%s' % (80 * '='))
+print('%s\n' % (80 * '='))
+print('Testing Percentage Indicator Generator\n')
 
-    Parameters
-    ----------
-    iterations : `int`
-      Number of iterations for the iterative computation.
+for i in pyprind.prog_percent(range(n), stream=sys.stdout):
+    # do something
+    pass
 
-    track_time : `bool` (default = `True`)
-      Prints elapsed time when loop has finished.
 
-    stream : `int` (default = 2).
-      Setting the output stream.
-      Takes `1` for stdout, `2` for stderr, or a custom stream object
+print('\n%s' % (80 * '='))
+print('%s\n' % (80 * '='))
+print('Testing monitor function\n')
 
-    title : `str` (default = `''`).
-      Setting a title for the percentage indicator.
+perc = pyprind.ProgPercent(n, monitor=True)
+for i in range(n):
+    perc.update()
+print(perc)
 
-    monitor : `bool` (default = False)
-      Monitors CPU and memory usage if `True` (requires `psutil` package).
 
-    """
-    def __init__(self, iterations, track_time=True,
-                 stream=2, title='', monitor=False):
-        Prog.__init__(self, iterations, track_time, stream, title, monitor)
-        self.last_progress = 0
-        self._print()
-        if monitor:
-            try:
-                self.process.cpu_percent()
-                self.process.memory_percent()
-            except AttributeError:  # old version of psutil
-                self.process.get_cpu_percent()
-                self.process.get_memory_percent()
+print('\n%s' % (80 * '='))
+print('%s\n' % (80 * '='))
+print('Testing Item Tracking\n')
 
-    def _print(self):
-        """ Prints formatted integer percentage and tracked time to the screen."""
-        next_perc = self._calc_percent()
-        if next_perc > self.last_progress and self.active:
-            self.last_progress = next_perc
-            self._stream_out('\r[%3d %%]' % (self.last_progress))
-            if self.track:
-                self._stream_out(' Time elapsed: ' + self._get_time(self._elapsed()))
-                self._print_eta()
-            if self.item_id:
-                self._print_item_id()
+items = ['file_%s.csv' % i for i in range(0, n)]
+perc = pyprind.ProgPercent(len(items))
+for i in items:
+    # do some computation
+    perc.update(item_id=i)


### PR DESCRIPTION
For the issue https://github.com/rasbt/pyprind/issues/17 discussing the support for displaying long ETAs in hours and minutes. Added a function _get_time that takes time in seconds and returns a formatted string in the form of day, hour, min and sec.