### PR TITLE
Fix typo (inlcude) in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 include LICENSE
 include README.md
 include CONTRIBUTING.md
-inlcude CHANGELOG.md
+include CHANGELOG.md
 include tests/*


### PR DESCRIPTION
During certain certain build stages (eg: egg_info), the following warning is observed:
```
reading manifest template 'MANIFEST.in'
warning: manifest_maker: MANIFEST.in, line 4: unknown action 'inlcude'
```
Fix misspelling in MANIFEST.in accordingly