### PR TITLE
raise `ValueError` if `monitor` is set to `True` and `psutils` is not

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+Version 2.9.8
+================
+- raise `ValueError` if `monitor` is set to `True` and `psutils` is not installed
+
+
 Version 2.9.7
 ================
 - requirements.txt for `psutil`, now supports `pip install pyprind -r requirements.txt`

--- a/pyprind/__init__.py
+++ b/pyprind/__init__.py
@@ -17,4 +17,4 @@ from .generator_factory import prog_percent
 from .generator_factory import prog_bar
 
 
-__version__ = '2.9.7'
+__version__ = '2.9.8'

--- a/pyprind/prog_class.py
+++ b/pyprind/prog_class.py
@@ -16,6 +16,12 @@ import sys
 import os
 from io import UnsupportedOperation
 
+try:
+    import psutil
+    psutil_import = True
+except ImportError:
+    psutil_import = False
+
 
 class Prog():
     def __init__(self, iterations, track_time, stream, title,
@@ -40,9 +46,12 @@ class Prog():
         self._print_title()
         self.update_interval = update_interval
 
-        if self.monitor:
-            import psutil
-            self.process = psutil.Process()
+        if monitor:
+            if not psutil_import:
+                raise ValueError('psutil package is required when using'
+                                 ' the `monitor` option.')
+            else:
+                self.process = psutil.Process()
         if self.track:
             self.eta = 1
 


### PR DESCRIPTION
… installed